### PR TITLE
Cleanup/protocols

### DIFF
--- a/CatsApp.xcodeproj/project.pbxproj
+++ b/CatsApp.xcodeproj/project.pbxproj
@@ -664,8 +664,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 6J895MLH96;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.2;
 				MARKETING_VERSION = 1.0;
@@ -682,8 +684,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 6J895MLH96;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.2;
 				MARKETING_VERSION = 1.0;
@@ -701,6 +705,7 @@
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 6J895MLH96;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = metatracker.CatsAppUITests;
@@ -717,6 +722,7 @@
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 6J895MLH96;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = metatracker.CatsAppUITests;

--- a/CatsApp/App/CatsAppApp.swift
+++ b/CatsApp/App/CatsAppApp.swift
@@ -1,10 +1,3 @@
-//
-//  CatsAppApp.swift
-//  CatsApp
-//
-//  Created by Carlos Costa on 01/08/2025.
-//
-
 import SwiftData
 import SwiftUI
 

--- a/CatsApp/Core/Config/SecretsDecoder.swift
+++ b/CatsApp/Core/Config/SecretsDecoder.swift
@@ -1,10 +1,3 @@
-//
-//  SecretsD.swift
-//  CatsApp
-//
-//  Created by Carlos Costa on 02/10/2025.
-//
-
 import Foundation
 
 enum SecretsDecoder{

--- a/CatsApp/Core/Errors/DomainError.swift
+++ b/CatsApp/Core/Errors/DomainError.swift
@@ -1,10 +1,3 @@
-//
-//  DomainError.swift
-//  CatsApp
-//
-//  Created by Carlos Costa on 03/10/2025.
-//
-
 import Foundation
 
 enum DomainError: Error, LocalizedError, Equatable {

--- a/CatsApp/Core/Network/NetworkClient.swift
+++ b/CatsApp/Core/Network/NetworkClient.swift
@@ -22,7 +22,7 @@ enum NetworkError: Error, CustomStringConvertible {
 }
 
 struct NetworkClient {
-    var requestData: (_ endpoint: Endpoint) async throws -> Data
+    public internal(set) var requestData: (_ endpoint: Endpoint) async throws -> Data
     
     init(requestData: @escaping (_ endpoint: Endpoint) async throws -> Data) {
         self.requestData = requestData

--- a/CatsApp/Core/Network/NetworkClient.swift
+++ b/CatsApp/Core/Network/NetworkClient.swift
@@ -21,51 +21,50 @@ enum NetworkError: Error, CustomStringConvertible {
     }
 }
 
-protocol NetworkClientProtocol {
-    func request<T: Decodable>(_ endpoint: Endpoint) async throws -> T
+struct NetworkClient {
+    var requestData: (_ endpoint: Endpoint) async throws -> Data
+    
+    init(requestData: @escaping (_ endpoint: Endpoint) async throws -> Data) {
+        self.requestData = requestData
+    }
 }
 
-struct NetworkClient: NetworkClientProtocol {
-    let baseURL: URL
-    let urlSession: URLSession
-    let defaultHeaders: [String: String]
-
-    init(
+extension NetworkClient {
+    static func live(
         baseURL: URL = URL(string: "https://api.thecatapi.com/v1")!,
         urlSession: URLSession = .shared,
         defaultHeaders: [String: String] = [
             "x-api-key": SecretsDecoder.breedsApiKey
         ]
-    ) {
-        self.baseURL = baseURL
-        self.urlSession = urlSession
-        self.defaultHeaders = defaultHeaders
-    }
-
-    func request<T: Decodable>(_ endpoint: Endpoint) async throws -> T {
-        guard
-            let urlRequest = endpoint.makeRequest(
-                baseURL: baseURL,
-                defaultHeaders: defaultHeaders
-            )
-        else {
-            throw NetworkError.invalidRequest
-        }
-        do {
-            let (data, response) = try await urlSession.data(for: urlRequest)
-            if let http = response as? HTTPURLResponse,
-                !(200...299).contains(http.statusCode)
-            {
-                throw NetworkError.serverStatus(http.statusCode)
+    ) -> NetworkClient {
+        NetworkClient(
+            requestData: { endpoint in
+                guard
+                    let urlRequest = endpoint.makeRequest(
+                        baseURL: baseURL,
+                        defaultHeaders: defaultHeaders
+                    )
+                else {
+                    throw NetworkError.invalidRequest
+                }
+                
+                do {
+                    let (data, response) = try await urlSession.data(for: urlRequest)
+                    
+                    if let http = response as? HTTPURLResponse,
+                        !(200...299).contains(http.statusCode)
+                    {
+                        throw NetworkError.serverStatus(http.statusCode)
+                    }
+                    
+                    return data
+                    
+                } catch let error as NetworkError {
+                    throw error
+                } catch {
+                    throw NetworkError.transport(error)
+                }
             }
-            do {
-                let decoded = try JSONDecoder().decode(T.self, from: data)
-                return decoded
-            } catch {
-                throw NetworkError.decoding(error)
-            }
-        } catch {
-            throw NetworkError.transport(error)
-        }
+        )
     }
 }

--- a/CatsApp/Core/Utilities/Average.swift
+++ b/CatsApp/Core/Utilities/Average.swift
@@ -1,10 +1,3 @@
-//
-//  Average.swift
-//  CatsApp
-//
-//  Created by Carlos Costa on 06/08/2025.
-//
-
 import Foundation
 import SwiftData
 

--- a/CatsApp/Data/Repository/BreedsRepository.swift
+++ b/CatsApp/Data/Repository/BreedsRepository.swift
@@ -20,7 +20,7 @@ struct BreedsRepository {
 
     static func live(
         service: BreedsFetching = BreedsDataService(),
-        database: DatabaseServiceProtocol = DatabaseService()
+        database: DatabaseService = DatabaseService.live()
     ) -> BreedsRepository {
         BreedsRepository(
             fetchPage: { page, limit, context in
@@ -30,7 +30,7 @@ struct BreedsRepository {
                         limit: limit
                     )
                     let count = dtos.count
-                    let saved = try database.saveBreeds(dtos, context: context)
+                    let saved = try database.saveBreeds(dtos, context)
                     return PageResult(breeds: saved, fetchedCount: count)
                 } catch let error as DomainError {
                     throw error
@@ -40,26 +40,26 @@ struct BreedsRepository {
             },
             savePage: { dtos, context in
                 do {
-                    return try database.saveBreeds(dtos, context: context)
+                    return try database.saveBreeds(dtos, context)
                 } catch {
                     throw error
                 }
             },
             toggleFavorite: { breed, context in
-                try database.toggleFavorite(breed, context: context)
+                try database.toggleFavorite(breed, context)
             },
             fetchFavorites: { context in
-                try database.fetchFavoriteBreeds(context: context)
+                try database.fetchFavoriteBreeds(context)
             },
             fetchAll: { context in
-                try database.fetchAllBreeds(context: context)
+                try database.fetchAllBreeds(context)
             },
             cacheImage: { breedId, urlString, context in
                 do {
                     try await database.cacheImage(
-                        forBreedId: breedId,
-                        withUrl: urlString,
-                        context: context
+                      breedId,
+                      urlString,
+                      context
                     )
                 } catch {
                     throw DomainError.customError(

--- a/CatsApp/Data/Repository/BreedsRepository.swift
+++ b/CatsApp/Data/Repository/BreedsRepository.swift
@@ -10,7 +10,7 @@ struct BreedsRepository {
     var fetchPage:
         @MainActor (Int, Int, ModelContext) async throws -> PageResult
     var savePage:
-        @MainActor ([BreedsDataService.CatBreed], ModelContext) async throws ->
+        @MainActor ([CatBreedDTO], ModelContext) async throws ->
             [CatBreed]
     var toggleFavorite: @MainActor (CatBreed, ModelContext) throws -> Void
     var fetchFavorites: @MainActor (ModelContext) throws -> [CatBreed]
@@ -19,15 +19,15 @@ struct BreedsRepository {
         @MainActor (String, String, ModelContext) async throws -> Void
 
     static func live(
-        service: BreedsFetching = BreedsDataService(),
+        service: BreedsDataService = BreedsDataService.live(),
         database: DatabaseService = DatabaseService.live()
     ) -> BreedsRepository {
         BreedsRepository(
             fetchPage: { page, limit, context in
                 do {
                     let dtos = try await service.fetchCatsData(
-                        page: page,
-                        limit: limit
+                        page,
+                        limit
                     )
                     let count = dtos.count
                     let saved = try database.saveBreeds(dtos, context)
@@ -57,9 +57,9 @@ struct BreedsRepository {
             cacheImage: { breedId, urlString, context in
                 do {
                     try await database.cacheImage(
-                      breedId,
-                      urlString,
-                      context
+                        breedId,
+                        urlString,
+                        context
                     )
                 } catch {
                     throw DomainError.customError(

--- a/CatsApp/Data/Repository/BreedsRepository.swift
+++ b/CatsApp/Data/Repository/BreedsRepository.swift
@@ -7,15 +7,17 @@ struct PageResult {
 }
 
 struct BreedsRepository {
-    var fetchPage:
+    public internal(set) var fetchPage:
         @MainActor (Int, Int, ModelContext) async throws -> PageResult
-    var savePage:
-        @MainActor ([CatBreedDTO], ModelContext) async throws ->
-            [CatBreed]
-    var toggleFavorite: @MainActor (CatBreed, ModelContext) throws -> Void
-    var fetchFavorites: @MainActor (ModelContext) throws -> [CatBreed]
-    var fetchAll: @MainActor (ModelContext) throws -> [CatBreed]
-    var cacheImage:
+    public internal(set) var savePage:
+        @MainActor ([CatBreedDTO], ModelContext) async throws -> [CatBreed]
+    public internal(set) var toggleFavorite:
+        @MainActor (CatBreed, ModelContext) throws -> Void
+    public internal(set) var fetchFavorites:
+        @MainActor (ModelContext) throws -> [CatBreed]
+    public internal(set) var fetchAll:
+        @MainActor (ModelContext) throws -> [CatBreed]
+    public internal(set) var cacheImage:
         @MainActor (String, String, ModelContext) async throws -> Void
 
     static func live(

--- a/CatsApp/Data/Repository/BreedsRepository.swift
+++ b/CatsApp/Data/Repository/BreedsRepository.swift
@@ -1,104 +1,72 @@
 import Foundation
 import SwiftData
 
-protocol BreedsRepositoryProtocol {
-    @MainActor
-    func fetchPage(page: Int, limit: Int, context: ModelContext) async throws
-        -> PageResult
-    @MainActor
-    func savePage(_ dtos: [BreedsDataService.CatBreed], context: ModelContext)
-        async throws -> [CatBreed]
-    @MainActor
-    func toggleFavorite(_ breed: CatBreed, context: ModelContext) throws
-    @MainActor
-    func fetchFavorites(context: ModelContext) throws -> [CatBreed]
-    @MainActor
-    func fetchAll(context: ModelContext) throws -> [CatBreed]
-    @MainActor
-    func cacheImage(
-        forBreedId breedId: String,
-        withUrl urlString: String,
-        context: ModelContext
-    ) async throws
-}
-
 struct PageResult {
     let breeds: [CatBreed]
     let fetchedCount: Int
 }
 
-struct BreedsRepository: BreedsRepositoryProtocol {
-    private let service: BreedsFetching
-    private let database: DatabaseServiceProtocol
+struct BreedsRepository {
+    var fetchPage:
+        @MainActor (Int, Int, ModelContext) async throws -> PageResult
+    var savePage:
+        @MainActor ([BreedsDataService.CatBreed], ModelContext) async throws ->
+            [CatBreed]
+    var toggleFavorite: @MainActor (CatBreed, ModelContext) throws -> Void
+    var fetchFavorites: @MainActor (ModelContext) throws -> [CatBreed]
+    var fetchAll: @MainActor (ModelContext) throws -> [CatBreed]
+    var cacheImage:
+        @MainActor (String, String, ModelContext) async throws -> Void
 
-    init(
+    static func live(
         service: BreedsFetching = BreedsDataService(),
         database: DatabaseServiceProtocol = DatabaseService()
-    ) {
-        self.service = service
-        self.database = database
-    }
-
-    @MainActor
-    func fetchPage(page: Int, limit: Int, context: ModelContext) async throws
-        -> PageResult
-    {
-        do {
-            let dtos = try await service.fetchCatsData(
-                page: page,
-                limit: limit
-            )
-            let count = dtos.count
-            let saved = try database.saveBreeds(dtos, context: context)
-            return PageResult(breeds: saved, fetchedCount: count)
-        } catch let error as DomainError {
-            throw error
-        } catch {
-            throw DomainError.networkError
-        }
-    }
-
-    @MainActor
-    func savePage(_ dtos: [BreedsDataService.CatBreed], context: ModelContext)
-        async throws -> [CatBreed]
-    {
-        do {
-            return try database.saveBreeds(dtos, context: context)
-        } catch {
-            throw error
-        }
-    }
-
-    @MainActor
-    func toggleFavorite(_ breed: CatBreed, context: ModelContext) throws {
-        try database.toggleFavorite(breed, context: context)
-    }
-
-    @MainActor
-    func fetchFavorites(context: ModelContext) throws -> [CatBreed] {
-        try database.fetchFavoriteBreeds(context: context)
-    }
-
-    @MainActor
-    func fetchAll(context: ModelContext) throws -> [CatBreed] {
-        try database.fetchAllBreeds(context: context)
-    }
-    @MainActor
-    func cacheImage(
-        forBreedId breedId: String,
-        withUrl urlString: String,
-        context: ModelContext
-    ) async throws {
-        do {
-            try await database.cacheImage(
-                forBreedId: breedId,
-                withUrl: urlString,
-                context: context
-            )
-        } catch {
-            throw DomainError.customError(
-                "Failed to cache image: \(error.localizedDescription)"
-            )
-        }
+    ) -> BreedsRepository {
+        BreedsRepository(
+            fetchPage: { page, limit, context in
+                do {
+                    let dtos = try await service.fetchCatsData(
+                        page: page,
+                        limit: limit
+                    )
+                    let count = dtos.count
+                    let saved = try database.saveBreeds(dtos, context: context)
+                    return PageResult(breeds: saved, fetchedCount: count)
+                } catch let error as DomainError {
+                    throw error
+                } catch {
+                    throw DomainError.networkError
+                }
+            },
+            savePage: { dtos, context in
+                do {
+                    return try database.saveBreeds(dtos, context: context)
+                } catch {
+                    throw error
+                }
+            },
+            toggleFavorite: { breed, context in
+                try database.toggleFavorite(breed, context: context)
+            },
+            fetchFavorites: { context in
+                try database.fetchFavoriteBreeds(context: context)
+            },
+            fetchAll: { context in
+                try database.fetchAllBreeds(context: context)
+            },
+            cacheImage: { breedId, urlString, context in
+                do {
+                    try await database.cacheImage(
+                        forBreedId: breedId,
+                        withUrl: urlString,
+                        context: context
+                    )
+                } catch {
+                    throw DomainError.customError(
+                        "Failed to cache image: \(error.localizedDescription)"
+                    )
+                }
+            }
+        )
     }
 }

--- a/CatsApp/Data/Services/BreedsApiService.swift
+++ b/CatsApp/Data/Services/BreedsApiService.swift
@@ -7,59 +7,53 @@
 
 import Foundation
 
-protocol BreedsFetching {
-    func fetchCatsData(page: Int, limit: Int) async throws -> [BreedsDataService
-        .CatBreed]
+struct BreedsDataService {
+    var fetchCatsData: (Int, Int) async throws -> [CatBreedDTO]
 }
 
-struct BreedsDataService: BreedsFetching {
-
-    private let client: NetworkClientProtocol
-
-    init(client: NetworkClientProtocol = NetworkClient()) {
-        self.client = client
-    }
-
-    struct CatBreed: Codable {
-        let id: String
-        let name: String
-        let origin: String
-        let temperament: String
-        let description: String
-        let life_span: String
-        let reference_image_id: String?
-
-        private enum CodingKeys: String, CodingKey {
-            case id, name, origin, temperament, description
-            case life_span = "life_span"
-            case reference_image_id = "reference_image_id"
-        }
-    }
-
-    func fetchCatsData(page: Int = 0, limit: Int = 10) async throws
-        -> [CatBreed]
-    {
-        let endpoint = Endpoint(
-            path: "breeds",
-            queryItems: [
-                URLQueryItem(name: "page", value: String(page)),
-                URLQueryItem(name: "limit", value: String(limit)),
-            ]
-        )
-        do {
-            let breeds: [CatBreed] = try await client.request(endpoint)
-            return breeds
-        } catch let networkError as NetworkError {
-            switch networkError {
-            case .invalidRequest, .serverStatus, .transport:
-                throw DomainError.networkError
-            case .decoding:
-                throw DomainError.decodingError
-            case .unknown:
-                throw DomainError.unknownError
+extension BreedsDataService {
+    static func live(client: NetworkClientProtocol = NetworkClient()) -> BreedsDataService {
+        BreedsDataService(
+            fetchCatsData: { page, limit in
+                let endpoint = Endpoint(
+                    path: "breeds",
+                    queryItems: [
+                        URLQueryItem(name: "page", value: String(page)),
+                        URLQueryItem(name: "limit", value: String(limit)),
+                    ]
+                )
+                do {
+                    let breeds: [CatBreedDTO] = try await client.request(endpoint)
+                    return breeds
+                } catch let networkError as NetworkError {
+                    switch networkError {
+                    case .invalidRequest, .serverStatus, .transport:
+                        throw DomainError.networkError
+                    case .decoding:
+                        throw DomainError.decodingError
+                    case .unknown:
+                        throw DomainError.unknownError
+                    }
+                } catch {
+                    throw DomainError.unknownError
+                }
             }
-        } catch {
-            throw DomainError.unknownError
-        }
+        )
+    }
+}
+
+struct CatBreedDTO: Codable {
+    let id: String
+    let name: String
+    let origin: String
+    let temperament: String
+    let description: String
+    let life_span: String
+    let reference_image_id: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case id, name, origin, temperament, description
+        case life_span = "life_span"
+        case reference_image_id = "reference_image_id"
     }
 }

--- a/CatsApp/Data/Services/BreedsApiService.swift
+++ b/CatsApp/Data/Services/BreedsApiService.swift
@@ -46,19 +46,3 @@ extension BreedsDataService {
         )
     }
 }
-
-struct CatBreedDTO: Codable {
-    let id: String
-    let name: String
-    let origin: String
-    let temperament: String
-    let description: String
-    let life_span: String
-    let reference_image_id: String?
-
-    private enum CodingKeys: String, CodingKey {
-        case id, name, origin, temperament, description
-        case life_span = "life_span"
-        case reference_image_id = "reference_image_id"
-    }
-}

--- a/CatsApp/Data/Services/BreedsApiService.swift
+++ b/CatsApp/Data/Services/BreedsApiService.swift
@@ -1,10 +1,3 @@
-//
-//  DataService.swift
-//  CatsApp
-//
-//  Created by Carlos Costa on 03/08/2025.
-//
-
 import Foundation
 
 struct BreedsDataService {

--- a/CatsApp/Data/Services/BreedsApiService.swift
+++ b/CatsApp/Data/Services/BreedsApiService.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 struct BreedsDataService {
-    var fetchCatsData: (Int, Int) async throws -> [CatBreedDTO]
+    public internal(set) var fetchCatsData: (Int, Int) async throws -> [CatBreedDTO]
 }
 
 extension BreedsDataService {

--- a/CatsApp/Data/Services/BreedsApiService.swift
+++ b/CatsApp/Data/Services/BreedsApiService.swift
@@ -12,7 +12,7 @@ struct BreedsDataService {
 }
 
 extension BreedsDataService {
-    static func live(client: NetworkClientProtocol = NetworkClient()) -> BreedsDataService {
+    static func live(client: NetworkClient = NetworkClient.live()) -> BreedsDataService {
         BreedsDataService(
             fetchCatsData: { page, limit in
                 let endpoint = Endpoint(
@@ -23,8 +23,13 @@ extension BreedsDataService {
                     ]
                 )
                 do {
-                    let breeds: [CatBreedDTO] = try await client.request(endpoint)
-                    return breeds
+                    let data = try await client.requestData(endpoint)
+                    do {
+                        let breeds = try JSONDecoder().decode([CatBreedDTO].self, from: data)
+                        return breeds
+                    } catch {
+                        throw NetworkError.decoding(error)
+                    }
                 } catch let networkError as NetworkError {
                     switch networkError {
                     case .invalidRequest, .serverStatus, .transport:

--- a/CatsApp/Data/Services/DatabaseService.swift
+++ b/CatsApp/Data/Services/DatabaseService.swift
@@ -8,11 +8,16 @@ import Foundation
 import SwiftData
 
 struct DatabaseService {
-    var saveBreeds: @MainActor ([CatBreedDTO], ModelContext) throws -> [CatBreed]
-    var fetchAllBreeds: @MainActor (ModelContext) throws -> [CatBreed]
-    var fetchFavoriteBreeds: @MainActor (ModelContext) throws -> [CatBreed]
-    var toggleFavorite: @MainActor (CatBreed, ModelContext) throws -> Void
-    var cacheImage: @MainActor (String, String, ModelContext) async throws -> Void
+    public internal(set) var saveBreeds:
+        @MainActor ([CatBreedDTO], ModelContext) throws -> [CatBreed]
+    public internal(set) var fetchAllBreeds:
+        @MainActor (ModelContext) throws -> [CatBreed]
+    public internal(set) var fetchFavoriteBreeds:
+        @MainActor (ModelContext) throws -> [CatBreed]
+    public internal(set) var toggleFavorite:
+        @MainActor (CatBreed, ModelContext) throws -> Void
+    public internal(set) var cacheImage:
+        @MainActor (String, String, ModelContext) async throws -> Void
 }
 
 extension DatabaseService {
@@ -98,7 +103,9 @@ extension DatabaseService {
                 let descriptor = FetchDescriptor<CatBreed>(
                     predicate: #Predicate { $0.id == breedId }
                 )
-                guard let breed = try? context.fetch(descriptor).first else { return }
+                guard let breed = try? context.fetch(descriptor).first else {
+                    return
+                }
                 do {
                     let (data, _) = try await URLSession.shared.data(from: url)
                     breed.imageData = data

--- a/CatsApp/Data/Services/DatabaseService.swift
+++ b/CatsApp/Data/Services/DatabaseService.swift
@@ -7,127 +7,119 @@
 import Foundation
 import SwiftData
 
-protocol DatabaseServiceProtocol {
+struct DatabaseService {
 
-    @MainActor
-    func saveBreeds(_ dtos: [BreedsDataService.CatBreed], context: ModelContext)
-        throws -> [CatBreed]
-    @MainActor
-    func fetchAllBreeds(context: ModelContext) throws -> [CatBreed]
-    @MainActor
-    func fetchFavoriteBreeds(context: ModelContext) throws -> [CatBreed]
-    @MainActor
-    func toggleFavorite(_ breed: CatBreed, context: ModelContext) throws
-    @MainActor
-    func cacheImage(
-        forBreedId breedId: String,
-        withUrl urlString: String,
-        context: ModelContext
-    ) async throws
-}
+    var saveBreeds:
+        @MainActor ([BreedsDataService.CatBreed], ModelContext) throws ->
+            [CatBreed]
+    var fetchAllBreeds: @MainActor (ModelContext) throws -> [CatBreed]
+    var fetchFavoriteBreeds: @MainActor (ModelContext) throws -> [CatBreed]
+    var toggleFavorite: @MainActor (CatBreed, ModelContext) throws -> Void
+    var cacheImage:
+        @MainActor (String, String, ModelContext) async throws -> Void
 
-struct DatabaseService: DatabaseServiceProtocol {
+    static func live() -> DatabaseService {
+        DatabaseService(
+            saveBreeds: { dtos, context in
+                guard !dtos.isEmpty else {
+                    let descriptor = FetchDescriptor<CatBreed>()
+                    do {
+                        let all = try context.fetch(descriptor)
+                        return CatBreed.sortedByName(all)
+                    } catch {
+                        throw DomainError.persistenceError
+                    }
+                }
 
-    @MainActor
-    func saveBreeds(_ dtos: [BreedsDataService.CatBreed], context: ModelContext)
-        throws -> [CatBreed]
-    {
-        guard !dtos.isEmpty else { return try fetchAllBreeds(context: context) }
+                let existingDescriptor = FetchDescriptor<CatBreed>()
+                let existing: [CatBreed]
+                do {
+                    existing = try context.fetch(existingDescriptor)
+                } catch {
+                    throw DomainError.persistenceError
+                }
 
-        let existingDescriptor = FetchDescriptor<CatBreed>()
-        let existing: [CatBreed]
-        do {
-            existing = try context.fetch(existingDescriptor)
-        } catch {
-            throw DomainError.persistenceError
-        }
+                let existingIds = Set(existing.map { $0.id })
 
-        let existingIds = Set(existing.map { $0.id })
+                let newModels = dtos.compactMap { dto -> CatBreed? in
+                    guard !existingIds.contains(dto.id) else {
+                        return nil
+                    }
+                    return CatBreed(
+                        id: dto.id,
+                        name: dto.name,
+                        origin: dto.origin,
+                        temperament: dto.temperament,
+                        breedDescription: dto.description,
+                        lifeSpan: dto.life_span,
+                        referenceImageId: dto.reference_image_id,
+                        isFavorite: false
+                    )
+                }
 
-        let newModels = dtos.compactMap { dto -> CatBreed? in
-            guard !existingIds.contains(dto.id) else {
-                return nil
+                if !newModels.isEmpty {
+                    newModels.forEach { context.insert($0) }
+                    do {
+                        try context.save()
+                    } catch {
+                        throw DomainError.persistenceError
+                    }
+                }
+
+                do {
+                    let all = try context.fetch(existingDescriptor)
+                    return CatBreed.sortedByName(all)
+                } catch {
+                    throw DomainError.persistenceError
+                }
+
+            },
+            fetchAllBreeds: { context in
+                let descriptor = FetchDescriptor<CatBreed>()
+                do {
+                    let all = try context.fetch(descriptor)
+                    return CatBreed.sortedByName(all)
+                } catch {
+                    throw DomainError.persistenceError
+                }
+
+            },
+
+            fetchFavoriteBreeds: { context in
+                let predicate = #Predicate<CatBreed> { $0.isFavorite == true }
+                let descriptor = FetchDescriptor<CatBreed>(predicate: predicate)
+
+                do {
+                    let favorites = try context.fetch(descriptor)
+                    return CatBreed.sortedByName(favorites)
+                } catch {
+                    throw DomainError.persistenceError
+                }
+            },
+            toggleFavorite: { breed, context in
+                breed.isFavorite.toggle()
+                do {
+                    try context.save()
+                } catch {
+                    throw DomainError.persistenceError
+                }
+            },
+            cacheImage: { breedId, urlString, context in
+                guard let url = URL(string: urlString) else { return }
+                let descriptor = FetchDescriptor<CatBreed>(
+                    predicate: #Predicate { $0.id == breedId }
+                )
+                guard let breed = try? context.fetch(descriptor).first else {
+                    return
+                }
+                do {
+                    let (data, _) = try await URLSession.shared.data(from: url)
+                    breed.imageData = data
+                    try context.save()
+                } catch {
+                    throw DomainError.decodingError
+                }
             }
-            return CatBreed(
-                id: dto.id,
-                name: dto.name,
-                origin: dto.origin,
-                temperament: dto.temperament,
-                breedDescription: dto.description,
-                lifeSpan: dto.life_span,
-                referenceImageId: dto.reference_image_id,
-                isFavorite: false
-            )
-        }
-
-        if !newModels.isEmpty {
-            newModels.forEach { context.insert($0) }
-            do {
-                try context.save()
-            } catch {
-                throw DomainError.persistenceError
-            }
-        }
-
-        do {
-            let all = try context.fetch(existingDescriptor)
-            return CatBreed.sortedByName(all)
-        } catch {
-            throw DomainError.persistenceError
-        }
-    }
-
-    @MainActor
-    func fetchAllBreeds(context: ModelContext) throws -> [CatBreed] {
-        let descriptor = FetchDescriptor<CatBreed>()
-        do {
-            let all = try context.fetch(descriptor)
-            return CatBreed.sortedByName(all)
-        } catch {
-            throw DomainError.persistenceError
-        }
-    }
-
-    @MainActor
-    func fetchFavoriteBreeds(context: ModelContext) throws -> [CatBreed] {
-        let predicate = #Predicate<CatBreed> { $0.isFavorite == true }
-        let descriptor = FetchDescriptor<CatBreed>(predicate: predicate)
-
-        do {
-            let favorites = try context.fetch(descriptor)
-            return CatBreed.sortedByName(favorites)
-        } catch {
-            throw DomainError.persistenceError
-        }
-    }
-
-    @MainActor
-    func toggleFavorite(_ breed: CatBreed, context: ModelContext) throws {
-        breed.isFavorite.toggle()
-        do {
-            try context.save()
-        } catch {
-            throw DomainError.persistenceError
-        }
-    }
-
-    @MainActor
-    func cacheImage(
-        forBreedId breedId: String,
-        withUrl urlString: String,
-        context: ModelContext
-    ) async throws {
-        guard let url = URL(string: urlString) else { return }
-        let descriptor = FetchDescriptor<CatBreed>(
-            predicate: #Predicate { $0.id == breedId }
         )
-        guard let breed = try? context.fetch(descriptor).first else { return }
-        do {
-            let (data, _) = try await URLSession.shared.data(from: url)
-            breed.imageData = data
-            try context.save()
-        } catch {
-            throw DomainError.decodingError
-        }
     }
 }

--- a/CatsApp/Data/Services/DatabaseService.swift
+++ b/CatsApp/Data/Services/DatabaseService.swift
@@ -45,16 +45,7 @@ extension DatabaseService {
                     guard !existingIds.contains(dto.id) else {
                         return nil
                     }
-                    return CatBreed(
-                        id: dto.id,
-                        name: dto.name,
-                        origin: dto.origin,
-                        temperament: dto.temperament,
-                        breedDescription: dto.description,
-                        lifeSpan: dto.life_span,
-                        referenceImageId: dto.reference_image_id,
-                        isFavorite: false
-                    )
+                    return dto.toModel()
                 }
                 if !newModels.isEmpty {
                     newModels.forEach { context.insert($0) }

--- a/CatsApp/Data/Services/DatabaseService.swift
+++ b/CatsApp/Data/Services/DatabaseService.swift
@@ -8,7 +8,7 @@ import Foundation
 import SwiftData
 
 struct DatabaseService {
-    var saveBreeds: @MainActor ([BreedsDataService.CatBreed], ModelContext) throws -> [CatBreed]
+    var saveBreeds: @MainActor ([CatBreedDTO], ModelContext) throws -> [CatBreed]
     var fetchAllBreeds: @MainActor (ModelContext) throws -> [CatBreed]
     var fetchFavoriteBreeds: @MainActor (ModelContext) throws -> [CatBreed]
     var toggleFavorite: @MainActor (CatBreed, ModelContext) throws -> Void

--- a/CatsApp/Data/Services/DatabaseService.swift
+++ b/CatsApp/Data/Services/DatabaseService.swift
@@ -1,9 +1,3 @@
-//
-//  BreedsDataService.swift
-//  CatsApp
-//
-//  Created by Carlos Costa on 10/10/2025.
-//
 import Foundation
 import SwiftData
 

--- a/CatsApp/Data/Services/FavoritesService.swift
+++ b/CatsApp/Data/Services/FavoritesService.swift
@@ -14,18 +14,18 @@ struct FavoritesService {
     var toggleFavorite: @MainActor (CatBreed, ModelContext) throws -> Void
     var isFavorite: @MainActor (CatBreed, ModelContext) throws -> Bool
 
-    static func live(repository: BreedsRepository = BreedsRepository())
+    static func live(repository: BreedsRepository = BreedsRepository.live())
         -> FavoritesService
     {
         FavoritesService(
             fetchFavorites: { context in
-                try repository.fetchFavorites(context: context)
+                try repository.fetchFavorites(context)
             },
             toggleFavorite: { breed, context in
-                try repository.toggleFavorite(breed, context: context)
+                try repository.toggleFavorite(breed, context)
             },
             isFavorite: { breed, context in
-                let favorites = try repository.fetchFavorites(context: context)
+                let favorites = try repository.fetchFavorites(context)
                 return favorites.contains(where: { $0.id == breed.id })
             }
         )

--- a/CatsApp/Data/Services/FavoritesService.swift
+++ b/CatsApp/Data/Services/FavoritesService.swift
@@ -9,9 +9,12 @@ import Foundation
 import SwiftData
 
 struct FavoritesService {
-    var fetchFavorites: @MainActor (ModelContext) throws -> [CatBreed]
-    var toggleFavorite: @MainActor (CatBreed, ModelContext) throws -> Void
-    var isFavorite: @MainActor (CatBreed, ModelContext) throws -> Bool
+    public internal(set) var fetchFavorites:
+        @MainActor (ModelContext) throws -> [CatBreed]
+    public internal(set) var toggleFavorite:
+        @MainActor (CatBreed, ModelContext) throws -> Void
+    public internal(set) var isFavorite:
+        @MainActor (CatBreed, ModelContext) throws -> Bool
 }
 
 extension FavoritesService {

--- a/CatsApp/Data/Services/FavoritesService.swift
+++ b/CatsApp/Data/Services/FavoritesService.swift
@@ -1,10 +1,3 @@
-//
-//  FavoritesService.swift
-//  CatsApp
-//
-//  Created by Carlos Costa on 09/10/2025.
-//
-
 import Foundation
 import SwiftData
 

--- a/CatsApp/Data/Services/FavoritesService.swift
+++ b/CatsApp/Data/Services/FavoritesService.swift
@@ -9,11 +9,12 @@ import Foundation
 import SwiftData
 
 struct FavoritesService {
-
     var fetchFavorites: @MainActor (ModelContext) throws -> [CatBreed]
     var toggleFavorite: @MainActor (CatBreed, ModelContext) throws -> Void
     var isFavorite: @MainActor (CatBreed, ModelContext) throws -> Bool
+}
 
+extension FavoritesService {
     static func live(repository: BreedsRepository = BreedsRepository.live())
         -> FavoritesService
     {

--- a/CatsApp/Data/Services/SearchService.swift
+++ b/CatsApp/Data/Services/SearchService.swift
@@ -7,12 +7,10 @@
 
 import Foundation
 
-protocol SearchServiceProtocol {
-    func searchBreeds(query: String, in breeds: [CatBreed]) -> [CatBreed]
-}
-
-struct SearchService: SearchServiceProtocol {
-    func searchBreeds(query: String, in breeds: [CatBreed]) -> [CatBreed] {
+struct SearchService {
+    var searchBreeds: (String, [CatBreed]) -> [CatBreed]
+    
+    static let live = SearchService { query, breeds in
         guard !query.isEmpty else { return breeds }
         return breeds.filter {
             $0.name.lowercased().contains(query.lowercased())

--- a/CatsApp/Data/Services/SearchService.swift
+++ b/CatsApp/Data/Services/SearchService.swift
@@ -9,7 +9,9 @@ import Foundation
 
 struct SearchService {
     var searchBreeds: (String, [CatBreed]) -> [CatBreed]
-    
+}
+
+extension SearchService {
     static let live = SearchService { query, breeds in
         guard !query.isEmpty else { return breeds }
         return breeds.filter {

--- a/CatsApp/Data/Services/SearchService.swift
+++ b/CatsApp/Data/Services/SearchService.swift
@@ -1,10 +1,3 @@
-//
-//  SearchService.swift
-//  CatsApp
-//
-//  Created by Carlos Costa on 09/10/2025.
-//
-
 import Foundation
 
 struct SearchService {

--- a/CatsApp/Data/Services/SearchService.swift
+++ b/CatsApp/Data/Services/SearchService.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 struct SearchService {
-    var searchBreeds: (String, [CatBreed]) -> [CatBreed]
+    public internal(set) var searchBreeds: (String, [CatBreed]) -> [CatBreed]
 }
 
 extension SearchService {

--- a/CatsApp/Domain/DTOs/CatBreedDTO.swift
+++ b/CatsApp/Domain/DTOs/CatBreedDTO.swift
@@ -1,10 +1,3 @@
-//
-//  CatBreedDTO.swift
-//  CatsApp
-//
-//  Created by Carlos Costa on 21/10/2025.
-//
-
 import Foundation
 
 struct CatBreedDTO: Codable {

--- a/CatsApp/Domain/DTOs/CatBreedDTO.swift
+++ b/CatsApp/Domain/DTOs/CatBreedDTO.swift
@@ -1,0 +1,39 @@
+//
+//  CatBreedDTO.swift
+//  CatsApp
+//
+//  Created by Carlos Costa on 21/10/2025.
+//
+
+import Foundation
+
+struct CatBreedDTO: Codable {
+    let id: String
+    let name: String
+    let origin: String
+    let temperament: String
+    let description: String
+    let life_span: String
+    let reference_image_id: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case id, name, origin, temperament, description
+        case life_span = "life_span"
+        case reference_image_id = "reference_image_id"
+    }
+}
+
+extension CatBreedDTO {
+    func toModel() -> CatBreed {
+        return CatBreed(
+            id: self.id,
+            name: self.name,
+            origin: self.origin,
+            temperament: self.temperament,
+            breedDescription: self.description,
+            lifeSpan: self.life_span,
+            referenceImageId: self.reference_image_id,
+            isFavorite: false
+        )
+    }
+}

--- a/CatsApp/Domain/Mock/MockDTO.swift
+++ b/CatsApp/Domain/Mock/MockDTO.swift
@@ -1,10 +1,3 @@
-//
-//  MockDTO.swift
-//  CatsApp
-//
-//  Created by Carlos Costa on 08/10/2025.
-//
-
 import Foundation
 
 struct MockDTO {

--- a/CatsApp/Domain/Mock/MockDTO.swift
+++ b/CatsApp/Domain/Mock/MockDTO.swift
@@ -8,8 +8,8 @@
 import Foundation
 
 struct MockDTO {
-    static let breedsDTO: [BreedsDataService.CatBreed] = [
-        BreedsDataService.CatBreed(
+    static let breedsDTO: [CatBreedDTO] = [
+        CatBreedDTO(
             id: "abys",
             name: "Abyssinian",
             origin: "Egypt",
@@ -19,7 +19,7 @@ struct MockDTO {
             life_span: "14 - 15",
             reference_image_id: "0XYvRd7oD"
         ),
-        BreedsDataService.CatBreed(
+        CatBreedDTO(
             id: "aege",
             name: "Aegean",
             origin: "Greece",
@@ -29,7 +29,7 @@ struct MockDTO {
             life_span: "9 - 12",
             reference_image_id: nil
         ),
-        BreedsDataService.CatBreed(
+        CatBreedDTO(
             id: "abob",
             name: "American Bobtail",
             origin: "United States",
@@ -39,7 +39,7 @@ struct MockDTO {
             life_span: "11 - 15",
             reference_image_id: "hBXicehMA"
         ),
-        BreedsDataService.CatBreed(
+        CatBreedDTO(
             id: "acur",
             name: "American Curl",
             origin: "United States",
@@ -50,7 +50,7 @@ struct MockDTO {
             life_span: "12 - 16",
             reference_image_id: "xnsqonbjW"
         ),
-        BreedsDataService.CatBreed(
+        CatBreedDTO(
             id: "asho",
             name: "American Shorthair",
             origin: "United States",
@@ -60,7 +60,7 @@ struct MockDTO {
             life_span: "15 - 17",
             reference_image_id: "JFPROfGtQ"
         ),
-        BreedsDataService.CatBreed(
+        CatBreedDTO(
             id: "awir",
             name: "American Wirehair",
             origin: "United States",
@@ -71,7 +71,7 @@ struct MockDTO {
             life_span: "14 - 18",
             reference_image_id: "3bkZAjRh1"
         ),
-        BreedsDataService.CatBreed(
+        CatBreedDTO(
             id: "amau",
             name: "Arabian Mau",
             origin: "United Arab Emirates",
@@ -82,7 +82,7 @@ struct MockDTO {
             life_span: "12 - 14",
             reference_image_id: nil
         ),
-        BreedsDataService.CatBreed(
+        CatBreedDTO(
             id: "amis",
             name: "Australian Mist",
             origin: "Australia",
@@ -92,7 +92,7 @@ struct MockDTO {
             life_span: "12 - 16",
             reference_image_id: "5AdhMZf6P"
         ),
-        BreedsDataService.CatBreed(
+        CatBreedDTO(
             id: "bali",
             name: "Balinese",
             origin: "United States",
@@ -102,7 +102,7 @@ struct MockDTO {
             life_span: "10 - 15",
             reference_image_id: "13MkvUe8X"
         ),
-        BreedsDataService.CatBreed(
+        CatBreedDTO(
             id: "bamb",
             name: "Bambino",
             origin: "United States",
@@ -112,7 +112,7 @@ struct MockDTO {
             life_span: "9 - 15",
             reference_image_id: nil
         ),
-        BreedsDataService.CatBreed(
+        CatBreedDTO(
             id: "beng",
             name: "Bengal",
             origin: "United States",
@@ -122,7 +122,7 @@ struct MockDTO {
             life_span: "12 - 16",
             reference_image_id: "O3btzLlsO"
         ),
-        BreedsDataService.CatBreed(
+        CatBreedDTO(
             id: "birm",
             name: "Birman",
             origin: "France",
@@ -132,7 +132,7 @@ struct MockDTO {
             life_span: "14 - 16",
             reference_image_id: "HkNS3lqX7"
         ),
-        BreedsDataService.CatBreed(
+        CatBreedDTO(
             id: "bomb",
             name: "Bombay",
             origin: "United States",

--- a/CatsApp/Domain/Mock/MockData.swift
+++ b/CatsApp/Domain/Mock/MockData.swift
@@ -1,10 +1,3 @@
-//
-//  MockData.swift
-//  CatsApp
-//
-//  Created by Carlos Costa on 01/10/2025.
-//
-
 import Foundation
 
 enum MockData {

--- a/CatsApp/Domain/Models/CatInfoModel.swift
+++ b/CatsApp/Domain/Models/CatInfoModel.swift
@@ -1,10 +1,3 @@
-//
-//  CatInfoModel.swift
-//  CatsApp
-//
-//  Created by Carlos Costa on 03/08/2025.
-//
-
 import Foundation
 import SwiftData
 

--- a/CatsApp/Presentation/ViewModels/BreedsViewModel/BreedsViewModel+Cache.swift
+++ b/CatsApp/Presentation/ViewModels/BreedsViewModel/BreedsViewModel+Cache.swift
@@ -23,7 +23,7 @@ extension BreedsViewModel {
     @discardableResult
     private func loadCachedBreeds(from context: ModelContext) async -> Bool {
         do {
-            let saved = try repository.fetchAll(context: context)
+            let saved = try repository.fetchAll(context)
             guard !saved.isEmpty else { return false }
             catBreeds = saved
             currentPage = catBreeds.count / pageSize
@@ -39,7 +39,7 @@ extension BreedsViewModel {
 
     func loadCachedIfAvailable(context: ModelContext) {
         guard catBreeds.isEmpty else { return }
-        if let saved = try? repository.fetchAll(context: context),
+        if let saved = try? repository.fetchAll(context),
             !saved.isEmpty
         {
             catBreeds = saved

--- a/CatsApp/Presentation/ViewModels/BreedsViewModel/BreedsViewModel+Cache.swift
+++ b/CatsApp/Presentation/ViewModels/BreedsViewModel/BreedsViewModel+Cache.swift
@@ -1,10 +1,3 @@
-//
-//  Cache.swift
-//  CatsApp
-//
-//  Created by Carlos Costa on 07/08/2025.
-//
-
 import SwiftData
 
 extension BreedsViewModel {

--- a/CatsApp/Presentation/ViewModels/BreedsViewModel/BreedsViewModel+Loading.swift
+++ b/CatsApp/Presentation/ViewModels/BreedsViewModel/BreedsViewModel+Loading.swift
@@ -25,9 +25,9 @@ extension BreedsViewModel {
     private func loadPage(context: ModelContext, isInitial: Bool) async {
         do {
             let pageResult = try await repository.fetchPage(
-                page: currentPage,
-                limit: pageSize,
-                context: context
+                currentPage,
+                pageSize,
+                context
             )
             let fetchedCount = pageResult.fetchedCount
             catBreeds = pageResult.breeds
@@ -43,9 +43,9 @@ extension BreedsViewModel {
                     if breed.imageData == nil, let url = breed.referenceImageUrl
                     {
                         try? await self.repository.cacheImage(
-                            forBreedId: breed.id,
-                            withUrl: url,
-                            context: context
+                            breed.id,
+                            url,
+                            context
                         )
                     }
                 }

--- a/CatsApp/Presentation/ViewModels/BreedsViewModel/BreedsViewModel+Loading.swift
+++ b/CatsApp/Presentation/ViewModels/BreedsViewModel/BreedsViewModel+Loading.swift
@@ -1,10 +1,3 @@
-//
-//  Loading.swift
-//  CatsApp
-//
-//  Created by Carlos Costa on 07/08/2025.
-//
-
 import Foundation
 import SwiftData
 

--- a/CatsApp/Presentation/ViewModels/BreedsViewModel/BreedsViewModel.swift
+++ b/CatsApp/Presentation/ViewModels/BreedsViewModel/BreedsViewModel.swift
@@ -18,7 +18,7 @@ enum ViewState: Equatable {
 
 @MainActor
 final class BreedsViewModel: ObservableObject {
-    let repository: BreedsRepositoryProtocol
+    let repository: BreedsRepository
     let favoritesViewModel: FavoritesViewModel
     let searchService: SearchService
 
@@ -30,7 +30,7 @@ final class BreedsViewModel: ObservableObject {
     let pageSize = 10
 
     init(
-        repository: BreedsRepositoryProtocol = BreedsRepository(),
+        repository: BreedsRepository = BreedsRepository.live(),
         favoritesViewModel: FavoritesViewModel
     ) {
         self.repository = repository

--- a/CatsApp/Presentation/ViewModels/BreedsViewModel/BreedsViewModel.swift
+++ b/CatsApp/Presentation/ViewModels/BreedsViewModel/BreedsViewModel.swift
@@ -1,10 +1,3 @@
-//
-//  CatDataViewModel.swift
-//  CatsApp
-//
-//  Created by Carlos Costa on 03/08/2025.
-//
-
 import Foundation
 import SwiftData
 

--- a/CatsApp/Presentation/ViewModels/BreedsViewModel/BreedsViewModel.swift
+++ b/CatsApp/Presentation/ViewModels/BreedsViewModel/BreedsViewModel.swift
@@ -20,7 +20,7 @@ enum ViewState: Equatable {
 final class BreedsViewModel: ObservableObject {
     let repository: BreedsRepositoryProtocol
     let favoritesViewModel: FavoritesViewModel
-    let searchService: SearchServiceProtocol
+    let searchService: SearchService
 
     @Published var catBreeds: [CatBreed] = []
     @Published var searchText: String = ""
@@ -35,7 +35,7 @@ final class BreedsViewModel: ObservableObject {
     ) {
         self.repository = repository
         self.favoritesViewModel = favoritesViewModel
-        self.searchService = SearchService()
+        self.searchService = SearchService.live
     }
 
     func resetPaging() { currentPage = 0 }
@@ -55,7 +55,8 @@ final class BreedsViewModel: ObservableObject {
     }
 
     var filteredBreeds: [CatBreed] {
-        searchService.searchBreeds(query: searchText, in: catBreeds)
+        let filteredBreeds = searchService.searchBreeds(searchText, catBreeds)
+        return filteredBreeds
     }
 
     var favoriteBreeds: [CatBreed] { favoritesViewModel.favorites }

--- a/CatsApp/Presentation/ViewModels/FavoritesViewModel/FavoritesViewModel.swift
+++ b/CatsApp/Presentation/ViewModels/FavoritesViewModel/FavoritesViewModel.swift
@@ -4,36 +4,36 @@ import SwiftData
 @MainActor
 final class FavoritesViewModel: ObservableObject {
     @Published private(set) var favorites: [CatBreed] = []
-    private let service: FavoritesServiceProtocol
-    
-    init(service: FavoritesServiceProtocol = FavoritesService()) {
+    private let service: FavoritesService
+
+    init(service: FavoritesService = FavoritesService.live()) {
         self.service = service
     }
-    
+
     var favoriteBreeds: [CatBreed] {
         favorites
     }
-    
+
     func toggleFavorite(for breed: CatBreed, context: ModelContext) {
         do {
-            try service.toggleFavorite(breed, context: context)
+            try service.toggleFavorite(breed, context)
             loadFavorites(context: context)
         } catch {
             print("Failed to toggle favorite: \(error)")
         }
     }
-    
+
     func isFavorite(_ breed: CatBreed, context: ModelContext) -> Bool {
         do {
-            return try service.isFavorite(breed, context: context)
+            return try service.isFavorite(breed, context)
         } catch {
             return false
         }
     }
-    
+
     func loadFavorites(context: ModelContext) {
         do {
-            favorites = try service.fetchFavorites(context: context)
+            favorites = try service.fetchFavorites(context)
         } catch {
             favorites = []
         }

--- a/CatsApp/Presentation/Views/Cells/BreedListView.swift
+++ b/CatsApp/Presentation/Views/Cells/BreedListView.swift
@@ -1,10 +1,3 @@
-//
-//  BreedListView.swift
-//  CatsApp
-//
-//  Created by Carlos Costa on 07/08/2025.
-//
-
 import SwiftUI
 
 struct BreedListView<Header: View>: View {

--- a/CatsApp/Presentation/Views/Cells/BreedRowView.swift
+++ b/CatsApp/Presentation/Views/Cells/BreedRowView.swift
@@ -1,10 +1,3 @@
-//
-//  BreedRowView.swift
-//  CatsApp
-//
-//  Created by Carlos Costa on 06/08/2025.
-//
-
 import SwiftUI
 
 struct BreedRowView: View {

--- a/CatsApp/Presentation/Views/Components/AverageTabView.swift
+++ b/CatsApp/Presentation/Views/Components/AverageTabView.swift
@@ -1,10 +1,3 @@
-//
-//  AvgView.swift
-//  CatsApp
-//
-//  Created by Carlos Costa on 06/08/2025.
-//
-
 import SwiftUI
 
 struct AverageTabView: View {

--- a/CatsApp/Presentation/Views/Components/BreedThumbnailView.swift
+++ b/CatsApp/Presentation/Views/Components/BreedThumbnailView.swift
@@ -1,8 +1,3 @@
-//  BreedThumbnailView.swift
-//  CatsApp
-//
-//  Created by Carlos on 01/10/2025.
-//
 import SwiftUI
 
 struct BreedThumbnailView: View {

--- a/CatsApp/Presentation/Views/Components/ConstantsUI.swift
+++ b/CatsApp/Presentation/Views/Components/ConstantsUI.swift
@@ -1,10 +1,3 @@
-//
-//  ConstantsUI.swift
-//  CatsApp
-//
-//  Created by Carlos Costa on 16/10/2025.
-//
-
 import Foundation
 import SwiftUI
 

--- a/CatsApp/Presentation/Views/Components/DetailsInfoComponents/FavoritesButton.swift
+++ b/CatsApp/Presentation/Views/Components/DetailsInfoComponents/FavoritesButton.swift
@@ -1,9 +1,3 @@
-//  FavoritesButton.swift
-//  CatsApp
-//
-//  Created by Carlos Costa on 09/10/2025.
-//
-
 import SwiftUI
 
 struct FavoritesButton: View {

--- a/CatsApp/Presentation/Views/Components/ImageLoader.swift
+++ b/CatsApp/Presentation/Views/Components/ImageLoader.swift
@@ -1,8 +1,3 @@
-//  ShimmerPlaceholder.swift
-//  CatsApp
-//
-// Created by Carlos Costa on 01/10/2025.
-//
 import SwiftUI
 
 struct ImageLoader: View {

--- a/CatsApp/Presentation/Views/EmptyStates/FavoritesEmptyStateView.swift
+++ b/CatsApp/Presentation/Views/EmptyStates/FavoritesEmptyStateView.swift
@@ -1,10 +1,3 @@
-//
-//  FavoritesEmptyStateView.swift
-//  CatsApp
-//
-//  Created by Carlos Costa on 01/10/2025.
-//
-
 import SwiftUI
 
 struct FavoritesEmptyStateView: View {

--- a/CatsApp/Presentation/Views/Modifiers/SearchModifier.swift
+++ b/CatsApp/Presentation/Views/Modifiers/SearchModifier.swift
@@ -1,10 +1,3 @@
-//
-//  SearchModifier.swift
-//  CatsApp
-//
-//  Created by Carlos Costa on 01/10/2025.
-//
-
 import SwiftUI
 
 struct BreedSearchModifier: ViewModifier {

--- a/CatsApp/Presentation/Views/Modifiers/ShadowModifier.swift
+++ b/CatsApp/Presentation/Views/Modifiers/ShadowModifier.swift
@@ -1,10 +1,3 @@
-//
-//  ShadowModifier.swift
-//  CatsApp
-//
-//  Created by Carlos Costa on 16/10/2025.
-//
-
 import SwiftUI
 
 struct ShadowModifier: ViewModifier{

--- a/CatsApp/Presentation/Views/Screens/BreedTabView.swift
+++ b/CatsApp/Presentation/Views/Screens/BreedTabView.swift
@@ -1,10 +1,3 @@
-//
-//  BreedTabView.swift
-//  CatsApp
-//
-//  Created by Carlos Costa on 01/10/2025.
-//
-
 import SwiftUI
 
 struct BreedTabView: View {

--- a/CatsApp/Presentation/Views/Screens/BreedsView/BreedsView.swift
+++ b/CatsApp/Presentation/Views/Screens/BreedsView/BreedsView.swift
@@ -1,10 +1,3 @@
-//
-//  ContentView.swift
-//  CatsApp
-//
-//  Created by Carlos Costa on 01/08/2025.
-//
-
 import SwiftData
 import SwiftUI
 

--- a/CatsApp/Presentation/Views/Screens/DetailsView/DetailsView.swift
+++ b/CatsApp/Presentation/Views/Screens/DetailsView/DetailsView.swift
@@ -1,10 +1,3 @@
-//
-//  DetailsView.swift
-//  CatsApp
-//
-//  Created by Carlos Costa on 05/08/2025.
-//
-
 import SwiftData
 import SwiftUI
 

--- a/CatsApp/Presentation/Views/Screens/FavoritesView/FavoritesViews.swift
+++ b/CatsApp/Presentation/Views/Screens/FavoritesView/FavoritesViews.swift
@@ -1,10 +1,3 @@
-//
-//  FavoritesViews.swift
-//  CatsApp
-//
-//  Created by Carlos Costa on 05/08/2025.
-//
-
 import SwiftData
 import SwiftUI
 

--- a/Tests/CatsAppTests/BreedsDataServiceTests.swift
+++ b/Tests/CatsAppTests/BreedsDataServiceTests.swift
@@ -10,20 +10,19 @@ import Testing
 
 @testable import CatsApp
 
-final class MockBreedsService: BreedsFetching {
-    let breedsToReturn: [BreedsDataService.CatBreed]?
+struct MockBreedsService {
+    let breedsToReturn: [CatBreedDTO]?
     let errorToThrow: NetworkError?
 
     init(
-        breeds: [BreedsDataService.CatBreed]? = nil,
+        breeds: [CatBreedDTO]? = nil,
         error: NetworkError? = nil
     ) {
         self.breedsToReturn = breeds
         self.errorToThrow = error
     }
 
-    func fetchCatsData(page: Int, limit: Int) async throws -> [BreedsDataService
-        .CatBreed]
+    func fetchCatsData(page: Int, limit: Int) async throws -> [CatBreedDTO]
     {
         if let error = errorToThrow {
             throw error
@@ -92,9 +91,9 @@ struct BreedsDataServiceErrorTests {
         toMatch expected: DomainError
     ) async {
         let client = MockNetworkClient(error: networkError)
-        let service = BreedsDataService(client: client)
+        let service = BreedsDataService.live(client: client)
         await #expect(throws: expected) {
-            _ = try await service.fetchCatsData(page: 0, limit: 10)
+            _ = try await service.fetchCatsData(0, 10)
         }
     }
 

--- a/Tests/CatsAppTests/BreedsRepositoryTests.swift
+++ b/Tests/CatsAppTests/BreedsRepositoryTests.swift
@@ -16,16 +16,16 @@ import Testing
 struct BreedsRepositoryTests {
     @MainActor
     private func fetchBreeds(page: Int, limit: Int) async throws -> Int {
-        let repository = BreedsRepository(service: BreedsDataService())
+        let repository = BreedsRepository.live()
         let container = try ModelContainer(
             for: CatBreed.self,
             configurations: .init(isStoredInMemoryOnly: true)
         )
         let context = ModelContext(container)
         let result = try await repository.fetchPage(
-            page: page,
-            limit: limit,
-            context: context
+            page,
+            limit,
+            context
         )
         return result.breeds.count
     }
@@ -51,7 +51,7 @@ struct BreedsRepositoryTests {
         // page 6 returns fewer than 10 breeds
         // and page 7 returns 0 breeds as there are only 67 breeds in total so it is expected
         var allIds = Set<String>()
-        let repository = BreedsRepository(service: BreedsDataService())
+        let repository = BreedsRepository.live()
         let container = try ModelContainer(
             for: CatBreed.self,
             configurations: .init(isStoredInMemoryOnly: true)
@@ -59,12 +59,11 @@ struct BreedsRepositoryTests {
         let context = ModelContext(container)
         for page in pages {
             let result = try await repository.fetchPage(
-                page: page,
-                limit: limit,
-                context: context
+                page,
+                limit,
+                context
             )
             let newBreeds = Set(result.breeds.map { $0.id }).subtracting(allIds)
-
             print("\n--- Page \(page) ---")
             print("Total breeds returned: \(result.breeds.count)")
             print(
@@ -73,7 +72,6 @@ struct BreedsRepositoryTests {
             )
             print("\n--- Total ---")
             print("All breeds so far:", allIds.union(newBreeds).sorted())
-
             #expect(
                 newBreeds.count <= limit,
                 "Page \(page) should fetch \(limit) new breeds, got \(newBreeds.count)"


### PR DESCRIPTION
This pull request refactors the entire data and service layer (`NetworkClient`, `BreedsRepository`, `DatabaseService`, etc.) to use the struct-based "Protocol Witness" pattern. This change improves testability and clarity of dependencies throughout the codebase. Additionally, DTOs are standardized and mock data is updated for consistency.

**Refactoring to struct-based "Protocol Witness" pattern:**

* Protocols Removed: All service protocols (`NetworkClientProtocol`, `BreedsRepositoryProtocol`, `BreedsFetching`, `DatabaseServiceProtocol`, `FavoritesServiceProtocol`, `SearchServiceProtocol`) have been deleted.
* Instead of defining functions in a protocol, the struct's is now defined by its closure properties.
* `static func live()` Implementations: The "live" production logic (the code that actually performs network requests or database queries) has been moved into a `static func live()` on each struct.  This provides a single, clear entry point for the "production" version of the service while keeping the struct itself just a simple container of functions.

**DTO and data handling:**

* Introduced `CatBreedDTO` as a standalone struct for API data transfer, replacing previous nested DTOs and updating decoding logic accordingly.
* Updated all usages and mock data to use `CatBreedDTO` instead of the previous `BreedsDataService.CatBreed` type. 

**Testability and composability:**

* All unit tests have been updated. No longer use or need Mock classes (like `MockNetworkClient`).  Instead, mocks are created on the fly by initializing the struct with a specific closure for the test case.